### PR TITLE
Add PIKANs skeleton package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# PIKANs-Test
+# PIKANs Test Project
+
+본 레포지토리는 3파장 4-bucket 간섭계 데이터를 이용한 높이 복원 네트워크 "PIKANs"의 예시 구현을 위한 기본 구조를 제공합니다.
+
+## 구조
+
+- `pikan/` : 데이터셋, 전처리, 모델, 학습 루프 등 핵심 파이썬 모듈
+- `Doc/architecture/` : 4+1 뷰 아키텍처 설계 문서
+
+## 사용법
+
+```bash
+pip install -r requirements.txt
+```
+
+```python
+from pathlib import Path
+from pikan.config import TrainConfig
+from pikan.train import train
+
+config = TrainConfig(data_dir=Path("./data"))
+train(config)
+```

--- a/pikan/__init__.py
+++ b/pikan/__init__.py
@@ -1,0 +1,18 @@
+"""PIKANs 기본 모듈."""
+
+from .dataset import InterferogramDataset
+from .preprocessing import normalize_intensity, apply_roi, filter_noise
+from .model import PIKANsNetwork, physics_informed_loss
+from .config import TrainConfig
+from .train import train
+
+__all__ = [
+    "InterferogramDataset",
+    "normalize_intensity",
+    "apply_roi",
+    "filter_noise",
+    "PIKANsNetwork",
+    "physics_informed_loss",
+    "TrainConfig",
+    "train",
+]

--- a/pikan/config.py
+++ b/pikan/config.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class TrainConfig:
+    data_dir: Path
+    epochs: int = 10
+    batch_size: int = 4
+    learning_rate: float = 1e-3
+    device: str = "cuda"

--- a/pikan/dataset.py
+++ b/pikan/dataset.py
@@ -1,0 +1,22 @@
+import os
+from typing import List, Tuple
+import numpy as np
+from torch.utils.data import Dataset
+import cv2
+
+
+class InterferogramDataset(Dataset):
+    """3파장 4-bucket 간섭계 이미지를 로드하는 Dataset."""
+
+    def __init__(self, image_paths: List[str]):
+        self.image_paths = image_paths
+
+    def __len__(self) -> int:
+        return len(self.image_paths)
+
+    def __getitem__(self, idx: int) -> Tuple[np.ndarray, str]:
+        path = self.image_paths[idx]
+        image = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
+        if image is None:
+            raise FileNotFoundError(f"{path}를 열 수 없습니다.")
+        return image.astype(np.float32), os.path.basename(path)

--- a/pikan/model.py
+++ b/pikan/model.py
@@ -1,0 +1,23 @@
+import torch
+from torch import nn
+
+
+class PIKANsNetwork(nn.Module):
+    """KAN 기반 신경망 구조의 간단한 예."""
+
+    def __init__(self, input_channels: int = 12, hidden_dim: int = 64):
+        super().__init__()
+        self.conv1 = nn.Conv2d(input_channels, hidden_dim, kernel_size=3, padding=1)
+        self.relu = nn.ReLU()
+        self.conv2 = nn.Conv2d(hidden_dim, 1, kernel_size=3, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.relu(self.conv1(x))
+        return self.conv2(x)
+
+
+def physics_informed_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Physics-Informed loss의 예시 구현."""
+    data_loss = nn.functional.mse_loss(pred, target)
+    # 실제 물리 모델 기반 규제 항은 이곳에 추가
+    return data_loss

--- a/pikan/preprocessing.py
+++ b/pikan/preprocessing.py
@@ -1,0 +1,22 @@
+import cv2
+import numpy as np
+
+
+def normalize_intensity(image: np.ndarray) -> np.ndarray:
+    """이미지 intensity를 0~1 범위로 정규화."""
+    image = image.astype(np.float32)
+    min_val, max_val = image.min(), image.max()
+    if max_val - min_val == 0:
+        return np.zeros_like(image)
+    return (image - min_val) / (max_val - min_val)
+
+
+def apply_roi(image: np.ndarray, roi: tuple) -> np.ndarray:
+    """주어진 ROI를 잘라낸다."""
+    x, y, w, h = roi
+    return image[y:y + h, x:x + w]
+
+
+def filter_noise(image: np.ndarray, ksize: int = 3) -> np.ndarray:
+    """간단한 가우시안 블러를 적용한다."""
+    return cv2.GaussianBlur(image, (ksize, ksize), 0)

--- a/pikan/train.py
+++ b/pikan/train.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from torch.utils.data import DataLoader
+import torch
+
+from .dataset import InterferogramDataset
+from .preprocessing import normalize_intensity
+from .model import PIKANsNetwork, physics_informed_loss
+from .config import TrainConfig
+
+
+def load_dataset(data_dir: Path) -> InterferogramDataset:
+    image_paths = sorted(str(p) for p in data_dir.glob("*.png"))
+    return InterferogramDataset(image_paths)
+
+
+def train(config: TrainConfig) -> None:
+    dataset = load_dataset(config.data_dir)
+    loader = DataLoader(dataset, batch_size=config.batch_size, shuffle=True)
+    device = torch.device(config.device if torch.cuda.is_available() else "cpu")
+
+    model = PIKANsNetwork().to(device)
+    optim = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
+
+    for epoch in range(config.epochs):
+        for images, _ in loader:
+            images = normalize_intensity(images.numpy())
+            images = torch.from_numpy(images).unsqueeze(1).to(device)
+            # 타겟은 예시로 0 사용
+            target = torch.zeros_like(images)
+            pred = model(images)
+            loss = physics_informed_loss(pred, target)
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+        print(f"Epoch {epoch+1}: loss={loss.item():.4f}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+torch
+numpy
+opencv-python


### PR DESCRIPTION
## Summary
- add basic Python package `pikan`
- implement dataset loader, preprocessing, model, config and training loop
- document usage in README
- add minimal requirements list

## Testing
- `python -m py_compile pikan/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6857c112921c8321a78bbc047317c78e