### PR TITLE
Allow running train script directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ from pikan.train import train
 config = TrainConfig(data_dir=Path("./data"))
 train(config)
 ```
+
+패키지를 모듈로 실행하면 상대 임포트 문제가 발생하지 않습니다.
+
+```bash
+python -m pikan.train   # 또는 python pikan/train.py
+```

--- a/pikan/train.py
+++ b/pikan/train.py
@@ -2,10 +2,11 @@ from pathlib import Path
 from torch.utils.data import DataLoader
 import torch
 
-from .dataset import InterferogramDataset
-from .preprocessing import normalize_intensity
-from .model import PIKANsNetwork, physics_informed_loss
-from .config import TrainConfig
+# 절대 임포트를 사용해 스크립트 단독 실행 시에도 패키지가 정상 인식되도록 한다.
+from pikan.dataset import InterferogramDataset
+from pikan.preprocessing import normalize_intensity
+from pikan.model import PIKANsNetwork, physics_informed_loss
+from pikan.config import TrainConfig
 
 
 def load_dataset(data_dir: Path) -> InterferogramDataset:


### PR DESCRIPTION
## Summary
- switch to absolute imports in `pikan/train.py`
- document how to run the training module from the command line

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6857c3878704832182b332c0502e2b0f