### PR TITLE
Add VSCode launch config and CLI entry

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run PIKANs train",
+            "type": "python",
+            "request": "launch",
+            "module": "pikan.train",
+            "justMyCode": false,
+            "args": []
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ train(config)
 ```bash
 python -m pikan.train   # 또는 python pikan/train.py
 ```
+
+## VSCode에서 실행하기
+
+레포지토리 루트에는 VSCode용 `launch.json`이 포함되어 있습니다. VSCode에서
+프로젝트 폴더를 열고 F5(또는 "실행" 버튼)을 누르면 `pikan.train` 모듈이 자동으로
+실행됩니다. 데이터 경로 등 파라미터는 `launch.json`이나 커맨드 라인 인수로
+수정할 수 있습니다.

--- a/pikan/__main__.py
+++ b/pikan/__main__.py
@@ -1,0 +1,4 @@
+from .train import main
+
+if __name__ == "__main__":
+    main()

--- a/pikan/train.py
+++ b/pikan/train.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from torch.utils.data import DataLoader
 import torch
+import argparse
 
 # 절대 임포트를 사용해 스크립트 단독 실행 시에도 패키지가 정상 인식되도록 한다.
 from pikan.dataset import InterferogramDataset
@@ -34,3 +35,27 @@ def train(config: TrainConfig) -> None:
             loss.backward()
             optim.step()
         print(f"Epoch {epoch+1}: loss={loss.item():.4f}")
+
+
+def main() -> None:
+    """커맨드 라인에서 실행할 수 있도록 기본 진입점을 제공한다."""
+    parser = argparse.ArgumentParser(description="Train PIKANs model")
+    parser.add_argument("--data-dir", type=Path, default=Path("./data"), help="학습 이미지 폴더")
+    parser.add_argument("--epochs", type=int, default=10, help="학습 에폭 수")
+    parser.add_argument("--batch-size", type=int, default=4, help="배치 크기")
+    parser.add_argument("--lr", type=float, default=1e-3, help="학습률")
+    parser.add_argument("--device", type=str, default="cuda", help="사용할 디바이스")
+    args = parser.parse_args()
+
+    config = TrainConfig(
+        data_dir=args.data_dir,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        learning_rate=args.lr,
+        device=args.device,
+    )
+    train(config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add VSCode debug configuration to easily run training
- expose `main()` in `pikan.train` and provide `__main__` entry point
- document VSCode usage

## Testing
- `python -m pikan.train --help` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_6857c5ddef748321a3fb40e14ffe58bd