### PR TITLE
Fix: Correct Physics-Informed Loss Implementation

### DIFF
--- a/src/loss/physics_informed_loss.py
+++ b/src/loss/physics_informed_loss.py
@@ -1,43 +1,78 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
+import numpy as np
 
-class RobustPhysicsLoss(nn.Module):
-    def __init__(self, wavelengths, adaptive_mode=True):
+class PhysicsInformedLoss(nn.Module):
+    """
+    Calculates a physics-informed loss based on the interferometry equation:
+    I = A + B * cos(phi + delta)
+
+    The loss is the Mean Squared Error (MSE) between the original intensities
+    measured by the sensor and the intensities reconstructed using the model's
+    predicted height map.
+    """
+    def __init__(self, wavelengths, num_wavelengths, num_buckets):
+        """
+        Args:
+            wavelengths (torch.Tensor or list): A tensor or list containing the wavelengths used.
+            num_wavelengths (int): The number of different wavelengths.
+            num_buckets (int): The number of phase shift buckets.
+        """
         super().__init__()
+        if not isinstance(wavelengths, torch.Tensor):
+            wavelengths = torch.tensor(wavelengths, dtype=torch.float32)
         self.register_buffer('wavelengths', wavelengths)
-        self.adaptive_mode = adaptive_mode
         
-        # 학습 가능한 위상간격 (백업용)
-        init_shifts = torch.tensor([0.0, torch.pi/2, torch.pi, 3*torch.pi/2])
-        self.learnable_shifts = nn.Parameter(init_shifts.clone())
-        
+        self.num_wavelengths = num_wavelengths
+        self.num_buckets = num_buckets
+
+        # Define phase shifts based on the number of buckets.
+        # This assumes a standard, evenly spaced phase-shifting setup.
+        phase_shifts = torch.linspace(0, 2 * np.pi, num_buckets, endpoint=False)
+        self.register_buffer('phase_shifts', phase_shifts) # Shape: (num_buckets,)
+
     def forward(self, predicted_height, original_intensities):
-        intensities_reshaped = original_intensities.view(-1, 3, 4)
+        """
+        Calculates the physics-informed loss.
+
+        Args:
+            predicted_height (torch.Tensor): The height map predicted by the KAN model.
+                                             Shape: (batch_size, 1)
+            original_intensities (torch.Tensor): The raw intensity values from the sensor.
+                                                 Shape: (batch_size, num_wavelengths * num_buckets)
+
+        Returns:
+            torch.Tensor: The calculated physics loss value.
+        """
+        # Reshape intensities for easier processing
+        # Shape: (batch_size, num_wavelengths, num_buckets)
+        intensities = original_intensities.view(-1, self.num_wavelengths, self.num_buckets)
+        device = intensities.device
+
+        # --- Estimate A (background) and B (modulation) from original intensities ---
+        # A is the average intensity per pixel per wavelength
+        A = torch.mean(intensities, dim=2, keepdim=True)  # Shape: (batch_size, num_wavelengths, 1)
         
-        if self.adaptive_mode:
-            # Carré 알고리즘 사용 (위상간격 무관)
-            return self.carre_loss(predicted_height, intensities_reshaped)
-        else:
-            # 학습된 위상간격 사용
-            return self.standard_loss(predicted_height, intensities_reshaped)
-    
-    def carre_loss(self, predicted_height, intensities):
-        """Carré 기반 강건한 손실"""
-        total_loss = 0
-        
-        for w in range(3):
-            I = intensities[:, w, :]
-            I1, I2, I3, I4 = I[:, 0], I[:, 1], I[:, 2], I[:, 3]
-            
-            # Carré 위상 추출
-            actual_phase = torch.atan2(I4 - I2, I1 - I3 + 1e-8)
-            
-            # 예측 위상
-            pred_phase = (4 * torch.pi * predicted_height.squeeze()) / self.wavelengths[w]
-            
-            # 위상 정합 손실
-            phase_loss = 1 - torch.cos(actual_phase - pred_phase)
-            total_loss += torch.mean(phase_loss)
-            
-        return total_loss / 3
+        # B is related to the amplitude of the sinusoid, approximated by sqrt(2) * std(I)
+        B = torch.sqrt(torch.tensor(2.0, device=device)) * torch.std(intensities, dim=2, keepdim=True)
+        # Add a small epsilon to B to prevent it from being zero.
+        B = B + 1e-8 # Shape: (batch_size, num_wavelengths, 1)
+
+
+        # --- Reconstruct intensities using the physical model ---
+        # Calculate the phase from the predicted height
+        # phi = (4 * pi / lambda) * h
+        phi = (4 * np.pi * predicted_height.to(device)) / self.wavelengths.unsqueeze(0) # Shape: (batch_size, num_wavelengths)
+        phi = phi.unsqueeze(2) # Shape: (batch_size, num_wavelengths, 1)
+
+        # Calculate the full phase argument for the cosine function
+        cos_argument = phi + self.phase_shifts.to(device) # Shape: (batch_size, num_wavelengths, num_buckets)
+
+        # Reconstruct the intensities
+        reconstructed_intensities = A + B * torch.cos(cos_argument)
+
+        # --- Calculate the loss ---
+        # The loss is the mean squared error between original and reconstructed intensities
+        loss = nn.functional.mse_loss(reconstructed_intensities, intensities)
+
+        return loss


### PR DESCRIPTION
This commit addresses critical issues in the physics-informed loss function and its usage in the training script.

The key changes are:

1.  **Replaced Loss Logic**: The previous `RobustPhysicsLoss` using the Carré algorithm has been replaced with `PhysicsInformedLoss`. The new implementation correctly follows the physical model `I = A + B*cos(phi)` described in the architecture documents, ensuring the model is trained with the correct physical constraints.

2.  **Removed Hardcoded Dimensions**: The new loss function is no longer hardcoded to specific dimensions. It dynamically accepts `num_wavelengths` and `num_buckets` from the configuration, making it flexible and consistent with the rest of the project.

3.  **Fixed Training Script**: `train.py` has been updated to instantiate and use the new `PhysicsInformedLoss`, passing the correct parameters from the configuration file.

4.  **Bug Fixes & Cleanup**: Removed the incomplete/unreachable `standard_loss` branch and unused `learnable_shifts` parameter, resolving bugs and improving code clarity.

These changes fix the fundamental mismatch between the data generation model and the training objective, enabling the PIKANs model to be trained as originally intended.