### PR TITLE
feat: Add support for training with BMP image sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,77 @@ pip install -r requirements.txt
 
 ## 실행
 
-### 학습
+### 1. 시뮬레이션 데이터(PNG) 학습
+
+프로젝트에 포함된 기본 더미 데이터 생성 스크립트(`generate_4w_3b_data.py`)를 사용하여 PNG 형식의 이미지 세트를 생성하고 학습을 진행할 수 있습니다.
 
 ```bash
+# (선택 사항) 더미 PNG 이미지 데이터 생성 (5개 샘플)
+python scripts/generate_4w_3b_data.py --num_samples 5
+
+# PNG 데이터용 설정 파일로 학습 실행
 python train.py --config configs/4w3b_config.yaml
 ```
 
-### 추론
+### 2. 실제 데이터(BMP) 학습
+
+사용자의 실제 측정 데이터(.bmp 파일)를 사용하여 학습을 진행할 수 있습니다.
+
+**가. 데이터 폴더 구조화**
+
+실제 데이터는 여러 '세트(set)' 또는 '샘플(sample)'로 구성될 수 있습니다. 각 샘플 폴더는 아래와 같은 구조를 가져야 합니다.
+
+```
+data/
+└── my_bmp_data/             <- 사용자 데이터의 루트 폴더 (이름은 자유롭게 지정 가능)
+    ├── set_01/              <- 각 측정 세트(샘플) 폴더
+    │   ├── raw/             <- 실제 측정 이미지(.bmp) 저장
+    │   │   ├── w0_b0.bmp
+    │   │   ├── w0_b1.bmp
+    │   │   ├── w0_b2.bmp
+    │   │   ├── w1_b0.bmp
+    │   │   └── ... (총 12개 이미지: 4 파장 x 3 버킷)
+    │   └── gt/              <- Ground Truth 데이터 저장
+    │       └── height.npy   <- Ground Truth 높이 맵 (Numpy 배열)
+    │
+    └── set_02/
+        └── ...
+```
+
+- **파일 명명 규칙**: `w{파장인덱스}_b{버킷인덱스}.bmp` 형식을 따라야 합니다. (인덱스는 0부터 시작)
+- **`height.npy`**: Ground Truth 높이 맵은 `float32` 타입의 Numpy 배열로 저장되어야 합니다.
+
+**나. 설정 파일 수정**
+
+`configs/bmp_data_config.yaml` 파일을 열어 `data.path`를 위에서 생성한 사용자 데이터의 루트 폴더 경로로 수정합니다.
+
+```yaml
+# configs/bmp_data_config.yaml
+
+data:
+  # 이 부분을 실제 데이터가 있는 폴더 경로로 수정합니다.
+  # 예: "data/my_bmp_data"
+  path: "data/bmp_dummy_data"
+
+  layout:
+    # ...
+    file_pattern: "w{w_idx}_b{b_idx}.bmp" # 파일 형식이 .bmp인지 확인
+```
+
+**다. BMP 데이터 학습 실행**
+
+수정된 설정 파일을 사용하여 학습을 시작합니다.
 
 ```bash
-python predict.py --model_path outputs/models/20250622_203136/final_model.pth --data_path data/raw/benchmark/sample_005
+python train.py --config configs/bmp_data_config.yaml
+```
+
+### 3. 추론
+
+학습된 모델을 사용하여 새로운 데이터 샘플에 대한 높이 맵을 예측합니다.
+
+```bash
+# 형식: python predict.py --model_path <모델경로> --data_path <데이터샘플경로>
+# 예시:
+python predict.py --model_path outputs/models/20250822_212403/final_model.pth --data_path data/bmp_dummy_data/sample_000
 ```

--- a/configs/bmp_data_config.yaml
+++ b/configs/bmp_data_config.yaml
@@ -1,0 +1,38 @@
+# Configuration for 4-wavelength, 3-bucket BMP image data
+data:
+  # For testing, this points to the dummy bmp data.
+  # For real use, change this to the root folder of your BMP data sets.
+  path: "data/bmp_dummy_data"
+
+  # layout 섹션을 통해 데이터 구조를 정의합니다.
+  layout:
+    num_wavelengths: 4
+    num_buckets: 3
+    # File pattern for BMP files
+    file_pattern: "w{w_idx}_b{b_idx}.bmp" # 0-indexed file naming rule
+
+  normalization: "minmax"
+  roi: null # e.g., [10, 10, 246, 246] for [y_start, x_start, y_end, x_end]
+  num_workers: 4
+
+model:
+  kan_layers: [12, 64, 64, 1] # Input: 4 wavelengths * 3 buckets = 12 channels
+  grid_size: 5
+  spline_order: 3
+  wavelengths: [450.0, 532.0, 632.8, 780.0] # Wavelengths in nm for physics loss
+
+training:
+  batch_size: 4096
+  epochs: 5
+  learning_rate: 0.001
+  scheduler:
+    type: "StepLR"
+    step_size: 20
+    gamma: 0.1
+  loss_weights:
+    mse: 1.0
+    physics: 0.1 # Weight for the physics-informed loss
+
+output:
+  log_dir: "outputs/logs"
+  model_dir: "outputs/models"

--- a/scripts/generate_bmp_data.py
+++ b/scripts/generate_bmp_data.py
@@ -1,0 +1,101 @@
+import numpy as np
+import os
+import argparse
+from PIL import Image
+
+def generate_ground_truth_height_map(width, height):
+    """
+    가우시안 피크, 사인파, 기울어진 평면을 조합하여 복잡한 형태의 Ground Truth 높이 맵을 생성합니다.
+    단위는 나노미터(nm)입니다.
+    """
+    x = np.linspace(-5, 5, width)
+    y = np.linspace(-5, 5, height)
+    xx, yy = np.meshgrid(x, y)
+
+    # 다양한 형태의 표면 조합
+    peak = 150 * np.exp(-((xx - 1.5)**2 + (yy - 1.5)**2) / 4)
+    wave = 50 * np.sin(2 * xx) * np.cos(2 * yy)
+    plane = 10 * xx + 5 * yy
+
+    height_map = peak + wave + plane + 50  # 기본 높이 추가
+    # 약간의 노이즈 추가
+    noise = np.random.normal(0, 2, (height, width))
+    height_map += noise
+
+    return height_map.astype(np.float32)
+
+def simulate_interferometry(height_map, wavelengths, phase_shifts, output_dir):
+    """
+    4-파장, 3-bucket 간섭계 측정 과정을 시뮬레이션하고 결과 이미지를 저장합니다.
+    물리식: I = A + B * cos( (4*pi/lambda) * h + delta )
+    """
+    height, width = height_map.shape
+
+    # 배경(A) 및 변조(B) 강도 (약간의 불균일성 포함)
+    A = 128 + np.random.normal(0, 5, (height, width))
+    B = 100 + np.random.normal(0, 5, (height, width))
+
+    image_filenames = []
+
+    for i, wl in enumerate(wavelengths):
+        # 높이로부터 위상(phase) 계산
+        phi = (4 * np.pi / wl) * height_map
+
+        for j, delta in enumerate(phase_shifts):
+            # 현재 bucket의 간섭 강도 계산
+            intensity = A + B * np.cos(phi + delta)
+
+            # 측정 노이즈(shot noise) 추가
+            intensity += np.random.normal(0, 2, intensity.shape)
+
+            # 8-bit 이미지로 변환 (0-255)
+            intensity_clipped = np.clip(intensity, 0, 255)
+            intensity_uint8 = intensity_clipped.astype(np.uint8)
+
+            # 이미지 파일로 저장
+            img = Image.fromarray(intensity_uint8, 'L')
+            # 파일명 규칙: w{파장인덱스}_b{버킷인덱스}.bmp
+            filename = f"w{i}_b{j}.bmp"
+            filepath = os.path.join(output_dir, filename)
+            img.save(filepath)
+            image_filenames.append(filename)
+
+    print(f"생성 완료: {len(image_filenames)}개의 간섭 이미지가 {output_dir}에 저장되었습니다.")
+    return image_filenames
+
+def main():
+    parser = argparse.ArgumentParser(description="4-파장, 3-bucket 간섭계 시뮬레이션 데이터 생성기 (BMP 포맷)")
+    parser.add_argument('--output_dir', type=str, default='data/bmp_dummy_data', help="생성된 데이터를 저장할 기본 디렉터리")
+    parser.add_argument('--num_samples', type=int, default=3, help="생성할 데이터 샘플의 수")
+    parser.add_argument('--width', type=int, default=256, help="이미지 너비")
+    parser.add_argument('--height', type=int, default=256, help="이미지 높이")
+    args = parser.parse_args()
+
+    # 물리 파라미터 정의
+    wavelengths = [450.0, 532.0, 632.8, 780.0] # 4 파장
+    phase_shifts = [0, 2 * np.pi / 3, 4 * np.pi / 3] # 3-bucket
+
+    for i in range(args.num_samples):
+        sample_name = f"sample_{i:03d}"
+        sample_dir = os.path.join(args.output_dir, sample_name)
+        gt_dir = os.path.join(sample_dir, "gt")
+        raw_data_dir = os.path.join(sample_dir, "raw")
+
+        os.makedirs(gt_dir, exist_ok=True)
+        os.makedirs(raw_data_dir, exist_ok=True)
+
+        print(f"\n--- 샘플 생성 중: {sample_name} ---")
+
+        # 1. Ground Truth 높이 맵 생성 및 저장
+        gt_height_map = generate_ground_truth_height_map(args.width, args.height)
+        gt_filepath = os.path.join(gt_dir, "height.npy")
+        np.save(gt_filepath, gt_height_map)
+        print(f"Ground Truth 높이 맵 저장 완료: {gt_filepath}")
+
+        # 2. 간섭 무늬 이미지 시뮬레이션 및 저장
+        simulate_interferometry(gt_height_map, wavelengths, phase_shifts, raw_data_dir)
+
+    print(f"\n총 {args.num_samples}개의 샘플을 '{args.output_dir}'에 성공적으로 생성했습니다.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit adds the functionality to train the model using sets of BMP image files, as per the user's specification. This replaces the previous incorrect implementation that handled video files.

Key changes include:
- Added `configs/bmp_data_config.yaml`, a new configuration file tailored for loading data from .bmp files. The existing data loader in `src/data_loader/datasets.py` is capable of handling these files without modification.
- Added `scripts/generate_bmp_data.py` to generate multiple sample sets of dummy BMP images and corresponding ground truth files. This allows for testing the pipeline with the expected data structure.
- Updated `README.md` to provide clear, step-by-step instructions for users on how to structure their BMP data sets, modify the configuration file, and run the training process.